### PR TITLE
Optimize job listing queries

### DIFF
--- a/src/hooks/admin/fetch-country.ts
+++ b/src/hooks/admin/fetch-country.ts
@@ -1,5 +1,6 @@
 import { DB } from '@/lib/db';
 import { Country } from '@prisma/client';
+import { cache } from 'react';
 export const dynamic = 'force-dynamic';
 export const fetchAllCountries = async () => {
   const countries = await DB.country.findMany({
@@ -22,3 +23,22 @@ export const fetchCountry = async (
 
   return country;
 };
+
+export const fetchCountriesWithActiveJobCounts = cache(async () => {
+  const countries = await DB.country.findMany({
+    orderBy: {
+      createdAt: 'desc',
+    },
+    include: {
+      _count: {
+        select: {
+          jobs: {
+            where: { isActive: true },
+          },
+        },
+      },
+    },
+  });
+
+  return countries;
+});


### PR DESCRIPTION
## Summary
- add `fetchCountriesWithActiveJobCounts` for efficient job count retrieval
- refactor guest jobs page to use aggregated counts

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68745305854c83309a5c35493c076fea